### PR TITLE
Update (Compatibility)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,8 @@ jobs:
     name: Publish package
     steps:
       - uses: actions/checkout@v2
-      - name: Nanos Store Action
-        uses: nanos-world/nanos-store-action@v1.0
+      - name: Nanos Marketplace Action
+        uses: nanos-world/nanos-marketplace-action@v1.0
         with:
           folder: ''
           name: 'egui'

--- a/Client/Classes/GUI/GUIManager.lua
+++ b/Client/Classes/GUI/GUIManager.lua
@@ -4,7 +4,7 @@ function Manager:Constructor()
     self.m_Ready = EGUI.Classlib.Bind(Manager.Ready, self)
     self.m_Handler = EGUI.Classlib.Bind(Manager.Handler, self)
 
-    self.m_WebUI = WebUI("GUI", "file:///UI/index.html", true)
+    self.m_WebUI = WebUI("GUI", "file:///UI/index.html", WidgetVisibility.Visible)
     self.m_WebUI:Subscribe("Ready", self.m_Ready)
 
     self.m_Id = 1

--- a/Client/Index.lua
+++ b/Client/Index.lua
@@ -41,3 +41,5 @@ local files = {
 for _, file in ipairs(files) do
 	Package.Require(file)
 end
+
+Package.Export("EGUI", EGUI)

--- a/Package.toml
+++ b/Package.toml
@@ -16,16 +16,16 @@
     # whether to load all level entities on client - only enable it if your package needs to use level static meshes entities
     load_level_entities =   false
     # the game version (major.minor) at the time this package was created, for granting compatibility between breaking changes
-    compatibility_version = "1.36"
+    compatibility_version = "1.58"
     # packages requirements
     packages_requirements = [
-
+                            
     ]
     # asset packs requirements
     assets_requirements = [
-
+                            
     ]
     # compatible game modes
     compatible_game_modes = [
-
+                            
     ]


### PR DESCRIPTION
Based on egui 1.0.3 on the store
Support nanos 1.58
- Update Webui constructor
- Export EGUI table globally to support one VM format
- Fix game_mode flag in Package.toml